### PR TITLE
fixed typo in css

### DIFF
--- a/example/css/jquery.jOrgChart.css
+++ b/example/css/jquery.jOrgChart.css
@@ -36,7 +36,7 @@
   width                 : 96px;
   height                : 60px;
   z-index 				: 10;
-  margin:               : 0 2px;
+  margin               : 0 2px;
 }
 
 /* jQuery drag 'n drop */


### PR DESCRIPTION
double colon was removed for margin attribute
now nods display with spaces beetwen them
