### PR TITLE
Improved handling of none ID lists

### DIFF
--- a/example/jquery.jOrgChart.js
+++ b/example/jquery.jOrgChart.js
@@ -69,22 +69,25 @@
       // Drop event handler for nodes
       $('div.node').bind("drop", function handleDropEvent( event, ui ) {    
 	  
-        var targetLi = $this.find("[data-tree-node=" + $(this).data("tree-node") + "]");        
-        var sourceLi = $this.find("[data-tree-node=" + ui.draggable.data("tree-node") + "]");
+        var targetID = $(this).data("tree-node");
+        var targetLi = $this.find("li").filter(function() { return $(this).data("tree-node") === targetID; } );
+        var targetUl = targetLi.children('ul');
+		
+        var sourceID = ui.draggable.data("tree-node");		
+        var sourceLi = $this.find("li").filter(function() { return $(this).data("tree-node") === sourceID; } );		
         var sourceUl = sourceLi.parent('ul');
 
-		var targetUl = targetLi.children('ul');
-		if (targetUl.length > 0){
-			targetUl.append(sourceLi);
+        if (targetUl.length > 0){
+		    targetUl.append(sourceLi);
         } else {
-			targetLi.append("<ul></ul>");
-			targetLi.children('ul').append(sourceLi);
+		    targetLi.append("<ul></ul>");
+		    targetLi.children('ul').append(sourceLi);
         }
         
-		//Removes any empty lists
-		if (sourceUl.children().length === 0){
-			sourceUl.remove();
-		}
+        //Removes any empty lists
+        if (sourceUl.children().length === 0){
+            sourceUl.remove();
+        }
 		
       }); // handleDropEvent
         
@@ -124,9 +127,9 @@
 	
     //Increaments the node count which is used to link the source list and the org chart
 	nodeCount++;
-	$node.attr("data-tree-node", nodeCount);
+	$node.data("tree-node", nodeCount);
 	$nodeDiv = $("<div>").addClass("node")
-                                   .attr("data-tree-node", nodeCount)
+                                   .data("tree-node", nodeCount)
                                    .append($nodeContent);
 
     // Expand and contract nodes

--- a/jquery.jOrgChart.js
+++ b/jquery.jOrgChart.js
@@ -69,22 +69,25 @@
       // Drop event handler for nodes
       $('div.node').bind("drop", function handleDropEvent( event, ui ) {    
 	  
-        var targetLi = $this.find("[data-tree-node=" + $(this).data("tree-node") + "]");        
-        var sourceLi = $this.find("[data-tree-node=" + ui.draggable.data("tree-node") + "]");
+        var targetID = $(this).data("tree-node");
+        var targetLi = $this.find("li").filter(function() { return $(this).data("tree-node") === targetID; } );
+        var targetUl = targetLi.children('ul');
+		
+        var sourceID = ui.draggable.data("tree-node");		
+        var sourceLi = $this.find("li").filter(function() { return $(this).data("tree-node") === sourceID; } );		
         var sourceUl = sourceLi.parent('ul');
 
-		var targetUl = targetLi.children('ul');
-		if (targetUl.length > 0){
-			targetUl.append(sourceLi);
+        if (targetUl.length > 0){
+		    targetUl.append(sourceLi);
         } else {
-			targetLi.append("<ul></ul>");
-			targetLi.children('ul').append(sourceLi);
+		    targetLi.append("<ul></ul>");
+		    targetLi.children('ul').append(sourceLi);
         }
         
-		//Removes any empty lists
-		if (sourceUl.children().length === 0){
-			sourceUl.remove();
-		}
+        //Removes any empty lists
+        if (sourceUl.children().length === 0){
+            sourceUl.remove();
+        }
 		
       }); // handleDropEvent
         
@@ -124,9 +127,9 @@
 	
     //Increaments the node count which is used to link the source list and the org chart
 	nodeCount++;
-	$node.attr("data-tree-node", nodeCount);
+	$node.data("tree-node", nodeCount);
 	$nodeDiv = $("<div>").addClass("node")
-                                   .attr("data-tree-node", nodeCount)
+                                   .data("tree-node", nodeCount)
                                    .append($nodeContent);
 
     // Expand and contract nodes


### PR DESCRIPTION
I wanted to use your plugin in a project, however I have lots of li elements where they would not have IDs and would have exactly the same contents as other elements in the list therefore the way you were searching for list elements based on the contents of the element was not working.

So I altered the source to use the HTML5 data- attributes to store a node count on each li and div.node in the form of data-tree-node=1 and then when the drop event is raised I can link the two elements by using the jquery attribute selector and data() methods like so:

var sourceLi = $this.find("[data-tree-node=" + ui.draggable.data("tree-node") + "]");

I also made one other minor change which is I switched draggable's revert option to 'invalid' which I think works a lot better, however you may disagree.
