### PR TITLE
Add an option to ignore space used by collapsed nodes

### DIFF
--- a/jquery.jOrgChart.js
+++ b/jquery.jOrgChart.js
@@ -99,7 +99,8 @@
     chartElement : 'body',
     depth      : -1,
     chartClass : "jOrgChart",
-    dragAndDrop: false
+    dragAndDrop: false,
+    ignoreSpace: false
   };
   
   var nodeCount = 0;
@@ -141,7 +142,7 @@
           if($tr.hasClass('contracted')){
             $this.css('cursor','n-resize');
             $tr.removeClass('contracted').addClass('expanded');
-            $tr.nextAll("tr").css('visibility', '');
+            $tr.nextAll("tr").css(opts.ignoreSpace ? 'display' : 'visibility', '');
 
             // Update the <li> appropriately so that if the tree redraws collapsed/non-collapsed nodes
             // maintain their appearance
@@ -149,7 +150,8 @@
           }else{
             $this.css('cursor','s-resize');
             $tr.removeClass('expanded').addClass('contracted');
-            $tr.nextAll("tr").css('visibility', 'hidden');
+            if(opts.ignoreSpace) { $tr.nextAll("tr").css('display', 'none'); }
+            else { $tr.nextAll("tr").css('visibility', 'hidden'); }
 
             $node.addClass('collapsed');
           }
@@ -211,7 +213,8 @@
         $.each(classList, function(index,item) {
             if (item == 'collapsed') {
                 console.log($node);
-                $nodeRow.nextAll('tr').css('visibility', 'hidden');
+                if(opts.ignoreSpace) { $nodeRow.nextAll('tr').css('display', 'none'); }
+                else { $nodeRow.nextAll('tr').css('visibility', 'hidden'); }
                     $nodeRow.removeClass('expanded');
                     $nodeRow.addClass('contracted');
                     $nodeDiv.css('cursor','s-resize');

--- a/readme.markdown
+++ b/readme.markdown
@@ -117,9 +117,10 @@ Source code with an example is available [here](https://github.com/wesnolte/jOrg
 
 ##Configuration
 
-There are only 3 configuration options.
+There are only 5 configuration options.
 
 1. **chartElement** - used to specify which HTML element you'd like to append the OrgChart markup to. *[default='body']*
 2. **depth** - tells the code what depth to parse to. The default value of "-1" instructs it to parse like it's 1999. *[default=-1]*
 3. **chartClass** - the name of the style class that is assigned to the generated markup. *[default='jOrgChart']*
 4. **dragAndDrop** - determines whether the drag-and-drop feature of tree node elements is enabled. *[default=false]*
+5. **ignoreSpace** - if true, no space is used by collapsed nodes. if false, the width and height of the graph stays the same when collapsing nodes. *[default=false]*


### PR DESCRIPTION
Hello,

Here is a commit that add an option to use `display: none` instead of `visibility: hidden` to hide nodes.

Fixes #18
