### PR TITLE
Added fix for latest version of jQuery

### DIFF
--- a/example/example.html
+++ b/example/example.html
@@ -9,8 +9,8 @@
     <script type="text/javascript" src="prettify.js"></script>
     
     <!-- jQuery includes -->
-    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js"></script>
     
     <script src="jquery.jOrgChart.js"></script>
 

--- a/example/jquery.jOrgChart.js
+++ b/example/jquery.jOrgChart.js
@@ -54,7 +54,7 @@
         var sourceNode = $(this);
         sourceNode.parentsUntil('.node-container')
                    .find('*')
-                   .filter('.node:data(draggable)')
+                   .filter('.node:data(ui-draggable)')
                    .droppable('disable');
       });
 

--- a/example/jquery.jOrgChart.js
+++ b/example/jquery.jOrgChart.js
@@ -54,7 +54,7 @@
         var sourceNode = $(this);
         sourceNode.parentsUntil('.node-container')
                    .find('*')
-                   .filter('.node')
+                   .filter('.node:data(draggable)')
                    .droppable('disable');
       });
 

--- a/jquery.jOrgChart.js
+++ b/jquery.jOrgChart.js
@@ -54,7 +54,7 @@
         var sourceNode = $(this);
         sourceNode.parentsUntil('.node-container')
                    .find('*')
-                   .filter('.node:data(draggable)')
+                   .filter('.node:data(ui-draggable)')
                    .droppable('disable');
       });
 

--- a/jquery.jOrgChart.js
+++ b/jquery.jOrgChart.js
@@ -54,7 +54,7 @@
         var sourceNode = $(this);
         sourceNode.parentsUntil('.node-container')
                    .find('*')
-                   .filter('.node')
+                   .filter('.node:data(draggable)')
                    .droppable('disable');
       });
 


### PR DESCRIPTION
When using the latest version of jQuery/jQueryUI you get the error "cannot call methods on droppable prior to initialization; attempted to call method 'disable'"

This is a simple fix and I also updated the version of jQuery in the example.
